### PR TITLE
fix: allow node version 14

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,6 +17,7 @@ jobs:
     strategy:
       matrix:
         node-version:
+        - 14.x
         - 16.x
         - 18.x
 

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
         "nyc": "15.1.0"
     },
     "engines": {
-        "node": ">=16"
+        "node": ">=14"
     },
     "eslintConfig": {
         "extends": "creative-area/es2021/script",


### PR DESCRIPTION
See comment related to breaking change: https://github.com/TwicPics/url/commit/2c0857e26ac6c51a6d6b1885c6f9d1fd1481b0b7#r96610711


#### TODO
- [x] Update test coverage: https://github.com/TwicPics/url/blob/master/.github/workflows/test.yml#L19-L21